### PR TITLE
fix: adjust into to model 4 show custom order

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -26,6 +26,11 @@ on:
   #   # Run smoke test nightly at 2am UTC
   #   - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 env:
   K6_VERSION: '0.47.0'
 

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -7,6 +7,10 @@ on:
   #   - cron: '0 1 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   full-security-audit:
     name: Complete Security Audit

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,6 +10,11 @@ on:
   #   # Run weekly on Monday at 9am UTC
   #   - cron: '0 9 * * 1'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   brakeman:
     name: Brakeman Security Scan

--- a/app/controllers/api/v1/dashboard_controller.rb
+++ b/app/controllers/api/v1/dashboard_controller.rb
@@ -109,8 +109,11 @@ class Api::V1::DashboardController < Api::V1::BaseController
   def roster_status_data
     players = organization_scoped(Player).includes(:champion_pools)
 
+    # Order by role to ensure consistent order in by_role hash
+    by_role_ordered = players.ordered_by_role.group(:role).count
+
     {
-      by_role: players.group(:role).count,
+      by_role: by_role_ordered,
       by_status: players.group(:status).count,
       contracts_expiring: players.contracts_expiring_soon.count
     }

--- a/app/controllers/api/v1/players_controller.rb
+++ b/app/controllers/api/v1/players_controller.rb
@@ -14,8 +14,8 @@ class Api::V1::PlayersController < Api::V1::BaseController
       players = players.where('summoner_name ILIKE ? OR real_name ILIKE ?', search_term, search_term)
     end
 
-    # Pagination
-    result = paginate(players.order(:role, :summoner_name))
+    # Pagination - order by role (top, jungle, mid, adc, support) then by name
+    result = paginate(players.ordered_by_role.order(:summoner_name))
 
     render_success({
       players: PlayerSerializer.render_as_hash(result[:data]),

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -38,6 +38,18 @@ class Player < ApplicationRecord
     where(contract_end_date: Date.current..Date.current + days.days)
   }
   scope :by_tier, ->(tier) { where(solo_queue_tier: tier) }
+  scope :ordered_by_role, -> {
+    order(Arel.sql(
+      "CASE role
+        WHEN 'top' THEN 1
+        WHEN 'jungle' THEN 2
+        WHEN 'mid' THEN 3
+        WHEN 'adc' THEN 4
+        WHEN 'support' THEN 5
+        ELSE 6
+      END"
+    ))
+  }
 
   # Instance methods
   def current_rank_display


### PR DESCRIPTION
  1. Adicionado scope ordered_by_role no model Player (app/models/player.rb:41-52)

  - Usa CASE WHEN do SQL para ordenar na sequência correta: top → jungle → mid → adc → support

  2. Atualizado PlayersController (app/controllers/api/v1/players_controller.rb:18)

  - Substituiu .order(:role, :summoner_name) por .ordered_by_role.order(:summoner_name)
  - Agora ordena primeiro por posição (na ordem correta) e depois pelo nome do jogador

  3. Atualizado DashboardController (app/controllers/api/v1/dashboard_controller.rb:113)

  - O by_role agora também respeita a ordem correta das posições