### PR TITLE
fix:  riot id encoding

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
           get :stats
           post :import
           post :bulk_sync
+          get :search_riot_id
         end
         member do
           get :stats


### PR DESCRIPTION
  1. ✅ Permissões do Docker - Bundle cache sem permissão para o usuário app
  2. ✅ Variáveis de ambiente - Configurado para usar o .env corretamente no Docker
  3. ✅ Redis isolado - Usando database /1 para evitar conflito com outras apps
  4. ✅ Riot API Key - Nova chave carregada corretamente
  5. ✅ Bug no encoding de URLs - Espaços codificados como %20 ao invés de +
  6. ✅ Tentativa de múltiplas tags - Testa variações (flp, FLP, Flp, BR1, etc)